### PR TITLE
Update journal.html

### DIFF
--- a/docs/journal.html
+++ b/docs/journal.html
@@ -184,7 +184,7 @@
               <p style="line-height: 150%; margin-top: 5; margin-bottom: 5" align="left">　最後になりましたが，上記主旨をご理解いただきご協力いただけましたら幸いです。</p>
               <p style="line-height: 150%; margin-top: 5; margin-bottom: 5" align="left">　　〒153-8522　東京都目黒区青葉台４丁目９－６<br>
               財団法人日本地図センター内　　日本地図学会　事務局<br>
-              ｅメール　gakkai [at] jmc.or.jp　　TEL　03-3485-5410 FAX 03-3485-5593<br>
+              ｅメール　info [at] jcacj.org　　TEL　03-3485-5410 FAX 03-3485-5593<br>
               <b><font color="#FF0000" size="1">＊[at]を@に変換してメールを送信してください＊</font></b></p>
             </div>
           </div>
@@ -238,7 +238,7 @@
               <p style="line-height: 150%; margin-top: 5; margin-bottom: 5" align="left">　</p>
               <p style="line-height: 150%; margin-top: 5; margin-bottom: 5" align="left">　　〒153-8522　東京都目黒区青葉台４丁目９－６<br>
               財団法人日本地図センター内　　日本地図学会　事務局<br>
-              ｅメール　gakkai [at] jmc.or.jp　　TEL　03-3485-5410 FAX 03-3485-5593<br>
+              ｅメール　info [at] jcacj.org　　TEL　03-3485-5410 FAX 03-3485-5593<br>
               <b><font color="#FF0000" size="1">＊[at]を@に変換してメールを送信してください＊</font></b></p>
             </div>
           </div>
@@ -278,7 +278,7 @@
                 <p style="line-height: 150%; margin-top: 5; margin-bottom: 5" align="left">　最後になりましたが，このアーカイブ化事業が科学技術振興機構の2009年度事業であることから2009年12月末までに対象著作物の著作権譲渡を受ける必要があるため， 告知に十分な時間がとれていないことを深くお詫びいたします。事情をご理解いただき，よろしくご了解くださいますようお願い申し上げます。</p>                 
                 <p style="line-height: 150%; margin-top: 5; margin-bottom: 5" align="left">〒153-8522　東京都目黒区青葉台４丁目９－６<br>
                 財団法人日本地図センター内　　日本国際地図学会　事務局<br>
-                ｅメール　gakkai [at] jmc.or.jp　　TEL　03-3485-5410 FAX 03-3485-5593<br>
+                ｅメール　info [at] jcacj.org　　TEL　03-3485-5410 FAX 03-3485-5593<br>
                 <b><font color="#FF0000" size="1">＊[at]を@に変換してメールを送信してください＊</font></b>
               </p>
             </div>


### PR DESCRIPTION
日本地図学会 代表メール info@jcacj.org への更新。
古いメールアドレス gakkai@jmc.or.jp  gakkai [at] jmc.or.jp 表記が残っているようです。

もし他に同様の記述があればすべて info@jcacj.org への統一をお願いいたします。